### PR TITLE
Changed the Packet Delay module ID to prevent conflicts with other Meteor addons.

### DIFF
--- a/src/main/java/io/lolyay/addon/modules/PacketDelay.java
+++ b/src/main/java/io/lolyay/addon/modules/PacketDelay.java
@@ -36,7 +36,7 @@ public class PacketDelay extends Module {
     );
 
     public PacketDelay() {
-        super(DupersUnitedPublicAddon.CATEGORY, "packet-delay", "Delays packets.");
+        super(DupersUnitedPublicAddon.CATEGORY, "duper-packet-delay", "Delays packets.");
     }
 
 


### PR DESCRIPTION
Adjusted the Packet Delay module ID to avoid conflicts with other addons.
Packet Delay is a widely used module and commonly appears in multiple Meteor addons.